### PR TITLE
Document Segment 1 foundation release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,32 @@ All notable product changes for Networking Machine are tracked here. Released se
 
 ### Planned
 
-- Segment 1 foundation: deployable Next.js app, Supabase Postgres, Prisma schema, password gate, dashboard, primary nav routes, and Settings system health.
+- Segment 2 Gmail Drafts-First Spine: Google OAuth, one connected Gmail account, AI-generated 4-email sequences, approval review, and Gmail draft creation only.
+
+### Guardrails
+
+- No Gmail OAuth, Gmail scopes, Gmail draft creation, send behavior, scanner, scheduler, or auto-send begins until Segment 2 is explicitly started.
+
+## [v0.1.0] Foundation Deployable App
+
+### Added
+
+- Added missing primary workflow route surfaces for People, Draft Review, Gmail, Templates, Background, Calls, and Lead Research.
+- Replaced Settings with a system health page covering app version, environment, database connectivity, password gate, OpenAI configuration, Gmail placeholder status, and Segment 1 safety gates.
+- Added signed password-gate cookies so private routes require a server-verifiable auth cookie instead of a plain marker value.
+- Preserved Gmail as a locked placeholder for Segment 2.
+
+### Verified
+
+- Vercel production deploy succeeded for merge `f0c088ad3f6302849eb7bbb2e0780c7417f4e7a5`.
+- Production root redirects unauthenticated requests to `/login`.
+- Production rejects forged `networking_machine_auth=ok` cookies and redirects to `/login`.
+- Primary navigation route file smoke check passed for all required Segment 1 areas.
+- Gmail boundary search found no OAuth, scopes, Gmail API calls, draft creation, scanner, scheduler, or send behavior.
+
+### Known Verification Gap
+
+- Authenticated Dashboard and Settings health still need a production click-through with the real app password or a temporary verification method.
 
 ## [v0.0.0] Planning Baseline
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,7 +4,11 @@
 
 Segment 1: Foundation
 
-Current version: `v0.1.0` foundation work in progress
+Current version: `v0.1.0` foundation shipped to production
+
+Next segment: Segment 2 Gmail Drafts-First Spine, not started.
+
+Segment 2 may start only after Adam or a temporary verification method confirms the authenticated Dashboard and Settings health page in production.
 
 ## Segment 0 Plan
 
@@ -49,6 +53,14 @@ Status:
 ## Segment 1 Foundation Plan
 
 Objective: make the app deployable, protected, database-backed, and navigable without starting Gmail implementation.
+
+Release status:
+
+- Segment 1 PR: `https://github.com/Adam-Li-611/networking-machine/pull/13`
+- Production merge SHA: `f0c088ad3f6302849eb7bbb2e0780c7417f4e7a5`
+- Production URL: `https://networking-machine.vercel.app`
+- Release version: `v0.1.0`
+- Status: shipped, with authenticated UI health check pending because the local environment does not have the production app password.
 
 Build scope:
 
@@ -102,15 +114,20 @@ Current test evidence:
 - Password gate signed-cookie helper check passed: valid signed cookie accepted, plain `ok` cookie rejected, wrong-password signature rejected.
 - ASCII check passed for Segment 1 edited files.
 - Gmail boundary search found only existing stubs and new placeholder/status copy; no OAuth, scopes, Gmail API calls, draft creation, scanner, or auto-send implementation was added.
+- Vercel production deployment for merge `f0c088ad3f6302849eb7bbb2e0780c7417f4e7a5` reported success.
+- Production root smoke check passed: unauthenticated `https://networking-machine.vercel.app/` redirects to `/login?next=%2F`.
+- Production password-gate smoke check passed: forged cookie `networking_machine_auth=ok` against `/settings` redirects to `/login?next=%2Fsettings`.
+- Production login page smoke check passed: login copy and metadata identify the app as a private AI outreach command center.
 - `npm run build` could not run locally because `npm` is not installed in this environment (`zsh: command not found: npm`).
 
 Exit criteria:
 
-- Segment 1 acceptance criteria pass.
+- Segment 1 acceptance criteria pass at the code and deployment level.
 - `STATUS.md` records test evidence.
 - `CHANGELOG.md` has `v0.1.0`.
 - `docs/VERSION_LOG.md` has `v0.1.0`.
-- `docs/DECISIONS.md` includes any new major choices made during foundation work.
+- `docs/DECISIONS.md` includes the signed password gate choice.
+- Remaining manual check before Segment 2: authenticate with the production app password and confirm Dashboard plus Settings system health load successfully.
 
 ## Meaningful Change Log
 
@@ -121,6 +138,9 @@ Exit criteria:
 - Replaced Settings with system health and Segment 1 gate status.
 - Hardened the password gate so middleware verifies a signed auth cookie instead of trusting a plain `ok` cookie value.
 - Recorded local verification evidence and package-manager blocker.
+- Merged Segment 1 foundation PR #13.
+- Verified production smoke checks for unauthenticated redirect and forged-cookie rejection.
+- Released Segment 1 as `v0.1.0` in `CHANGELOG.md` and `docs/VERSION_LOG.md`.
 - Created Segment 0 governance plan.
 - Created Segment 1 foundation plan.
 - Created local GitHub label and milestone manifests.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -84,3 +84,17 @@ Consequences:
 - Meaningful changes update `STATUS.md`.
 - Major choices update this file.
 - Pull requests must include summary, files changed, tests, screenshots when UI changes, and version/log updates.
+
+## D-007: Password Gate Uses Signed Cookies
+
+Status: accepted
+
+Decision: Segment 1 protects private app routes with a server-verifiable signed auth cookie derived from `APP_PASSWORD`.
+
+Why: A plain cookie marker can be forged by a browser or script. The private single-user gate still needs a tamper-resistant session marker before Gmail, token storage, or recruiting data is added.
+
+Consequences:
+
+- Middleware verifies cookie format, timestamp, and HMAC signature before allowing private route access.
+- Changing `APP_PASSWORD` invalidates existing app sessions.
+- Future multi-user authentication can replace the password gate without relying on any unauthenticated cookie trust.

--- a/docs/VERSION_LOG.md
+++ b/docs/VERSION_LOG.md
@@ -4,7 +4,7 @@ Networking Machine uses semantic-ish product versions tied to product capability
 
 ## Current Version
 
-`v0.0.0` Planning baseline
+`v0.1.0` Foundation deployable app
 
 ## Version Ladder
 
@@ -20,9 +20,40 @@ Networking Machine uses semantic-ish product versions tied to product capability
 
 ## Releases
 
+### `v0.1.0` Foundation Deployable App
+
+Status: shipped to production
+
+Released through:
+
+- PR: `https://github.com/Adam-Li-611/networking-machine/pull/13`
+- Merge SHA: `f0c088ad3f6302849eb7bbb2e0780c7417f4e7a5`
+- Production URL: `https://networking-machine.vercel.app`
+
+Included:
+
+- Deployable Next.js App Router foundation.
+- Password gate hardening with signed auth cookies.
+- Primary workflow routes for Dashboard, People, Campaigns, Draft Review, Gmail, Templates, Background, Calls, Lead Research, and Settings.
+- Settings system health page.
+- Gmail placeholder status only.
+
+Verified:
+
+- Production deploy succeeded on Vercel.
+- Unauthenticated production root redirects to login.
+- Forged plain `networking_machine_auth=ok` cookie no longer opens private routes.
+- Local signed-cookie helper check passed.
+- Primary route file smoke check passed.
+- Gmail boundary search found no Segment 2 behavior.
+
+Pending manual verification:
+
+- Authenticated Dashboard and Settings health need a production click-through with the real app password or a temporary verification method.
+
 ### `v0.0.0` Planning Baseline
 
-Status: active
+Status: released
 
 Included:
 


### PR DESCRIPTION
## Summary

- Mark Segment 1 as shipped in `STATUS.md` with production smoke evidence.
- Add `v0.1.0` release notes to `CHANGELOG.md` and `docs/VERSION_LOG.md`.
- Record the signed password-gate cookie decision in `docs/DECISIONS.md`.

## Files Changed

- `STATUS.md`
- `CHANGELOG.md`
- `docs/VERSION_LOG.md`
- `docs/DECISIONS.md`

## Test Evidence

- Production root redirects unauthenticated requests to `/login?next=%2F`.
- Production rejects forged `networking_machine_auth=ok` cookie on `/settings` and redirects to `/login?next=%2Fsettings`.
- Local ASCII check passed for the changed docs.
- No app code changed in this PR.

## Screenshots

- Not applicable. Documentation-only change.